### PR TITLE
Add BLAS and LAPACK packages to sysroot [OC-310]

### DIFF
--- a/sysroot/sysroot-creator.sh
+++ b/sysroot/sysroot-creator.sh
@@ -61,6 +61,10 @@ DEBIAN_PACKAGES="\
   uuid-dev
   libgcc-10-dev
   libgcc-s1
+  libblas3
+  libblas-dev
+  liblapack3
+  liblapack-dev
 "
 
 DEBIAN_PACKAGES_AMD64="


### PR DESCRIPTION
This is required for the sparse householder QR changes in

https://github.com/swift-nav/orion-engine/pull/7126
https://github.com/swift-nav/rules_swiftnav/pull/109
https://github.com/swift-nav/albatross/pull/453
https://github.com/swift-nav/cmake/pull/167