### PR TITLE
sysroot: fix missing symlinks for blas and lapack [IO-60]

### DIFF
--- a/sysroot/sysroot-creator.sh
+++ b/sysroot/sysroot-creator.sh
@@ -355,12 +355,30 @@ StripChecksumsFromPackageList() {
 }
 
 ######################################################################
-#
+# This is the part of the script that brings shame upon your clan.
 ######################################################################
 
 HacksAndPatches() {
   Banner "Misc Hacks & Patches"
 
+  # In debian blas and lapack are virtual packages.
+  #
+  # As such - the alternatives system is responsible for ensuring that a
+  # libblas.so and liblapack.so are available in /usr/lib/${TRIPLE} -
+  # i.e. - they are in the linkers default search path.
+  #
+  # The implementation we're using here - libblas-dev, and liblapack-dev
+  # only install the libraries to /usr/lib/${TRIPLE}/blas and /usr/lib/${TRIPLE}/lapack
+  # which are not on the linkers default search paths.
+  #
+  # Typically the symlink creation is handled by their respective post install
+  # scripts - but since we're using dpkg-deb directly - we need to do it ourselves.
+  #
+  # Otherwise we have to hardcode the install locations in the build system.
+  # Dealing with the possible combinations of arch, os, whether we're building
+  # with a sysroot or not is a nightmare.
+  #
+  # This is a hack - but it's the least bad option.
   cd ${INSTALL_ROOT}/usr/lib/${TRIPLE}
   ln -s ./blas/libblas.so libblas.so
   ln -s ./blas/libblas.a libblas.a

--- a/sysroot/sysroot-creator.sh
+++ b/sysroot/sysroot-creator.sh
@@ -361,45 +361,12 @@ StripChecksumsFromPackageList() {
 HacksAndPatches() {
   Banner "Misc Hacks & Patches"
 
-  # Remove an unnecessary dependency on qtchooser.
-  # rm "${INSTALL_ROOT}/usr/lib/${TRIPLE}/qt-default/qtchooser/default.conf"
-
-  # libxcomposite1 is missing a symbols file.
-  # cp "${SCRIPT_DIR}/libxcomposite1-symbols" \
-  #   "${INSTALL_ROOT}/debian/libxcomposite1/DEBIAN/symbols"
-
-  # __GLIBC_MINOR__ is used as a feature test macro.  Replace it with the
-  # earliest supported version of glibc (2.26, obtained from the oldest glibc
-  # version in //chrome/installer/linux/debian/dist_packag_versions.json and
-  # //chrome/installer/linux/rpm/dist_package_provides.json).
-  local usr_include="${INSTALL_ROOT}/usr/include"
-  # local features_h="${usr_include}/features.h"
-  # sed -i 's|\(#define\s\+__GLIBC_MINOR__\)|\1 26 //|' "${features_h}"
-
-  # fcntl64() was introduced in glibc 2.28.  Make sure to use fcntl() instead.
-  # local fcntl_h="${INSTALL_ROOT}/usr/include/fcntl.h"
-  # sed -i '{N; s/#ifndef __USE_FILE_OFFSET64\(\nextern int fcntl\)/#if 1\1/}' \
-  #     "${fcntl_h}"
-
-  # Do not use pthread_cond_clockwait as it was introduced in glibc 2.30.
-  local cppconfig_h="${usr_include}/${TRIPLE}/c++/10/bits/c++config.h"
-  sed -i 's|\(#define\s\+_GLIBCXX_USE_PTHREAD_COND_CLOCKWAIT\)|// \1|' \
-    "${cppconfig_h}"
-
-  # This is for chrome's ./build/linux/pkg-config-wrapper
-  # which overwrites PKG_CONFIG_LIBDIR internally
-  SubBanner "Move pkgconfig scripts"
-  mkdir -p ${INSTALL_ROOT}/usr/lib/pkgconfig
-  mv ${INSTALL_ROOT}/usr/lib/${TRIPLE}/pkgconfig/* \
-      ${INSTALL_ROOT}/usr/lib/pkgconfig
-
-  # Avoid requiring unsupported glibc versions.
-  "${SCRIPT_DIR}/reversion_glibc.py" \
-    "${INSTALL_ROOT}/lib/${TRIPLE}/libc.so.6"
-  "${SCRIPT_DIR}/reversion_glibc.py" \
-    "${INSTALL_ROOT}/lib/${TRIPLE}/libm.so.6"
-  # "${SCRIPT_DIR}/reversion_glibc.py" \
-  #   "${INSTALL_ROOT}/lib/${TRIPLE}/libcrypt.so.1"
+  cd ${INSTALL_ROOT}/usr/lib/${TRIPLE}
+  ln -s ./blas/libblas.so libblas.so
+  ln -s ./blas/libblas.a libblas.a
+  ln -s ./lapack/liblapack.so liblapack.so
+  ln -s ./lapack/liblapack.a liblapack.a
+  cd -
 }
 
 InstallIntoSysroot() {
@@ -528,7 +495,7 @@ BuildSysroot() {
   local files_and_sha256sums="$(cat ${package_file})"
   StripChecksumsFromPackageList "$package_file"
   InstallIntoSysroot ${files_and_sha256sums}
-  # HacksAndPatches
+  HacksAndPatches
   # CleanupJailSymlinks
   # VerifyLibraryDeps
   CreateTarBall

--- a/sysroot/sysroot-creator.sh
+++ b/sysroot/sysroot-creator.sh
@@ -355,7 +355,7 @@ StripChecksumsFromPackageList() {
 }
 
 ######################################################################
-# This is the part of the script that brings shame upon your clan.
+#
 ######################################################################
 
 HacksAndPatches() {
@@ -376,9 +376,8 @@ HacksAndPatches() {
   #
   # Otherwise we have to hardcode the install locations in the build system.
   # Dealing with the possible combinations of arch, os, whether we're building
-  # with a sysroot or not is a nightmare.
-  #
-  # This is a hack - but it's the least bad option.
+  # with a sysroot or not, etc... is too much to keep straight. So we'll deal
+  # with it here.
   cd ${INSTALL_ROOT}/usr/lib/${TRIPLE}
   ln -s ./blas/libblas.so libblas.so
   ln -s ./blas/libblas.a libblas.a


### PR DESCRIPTION
To support cross-compiling from x86_64 to aarch64 debian targets - we're using some scripts from the chromium
project for building sysroots directly from debian (`.deb`) packages.

A caveat of using these scripts is they rely on very low level plumbing commands (i.e. `dpkg-deb`) to handle unpacking
and installing the package contents (libs and headers), into "jail" (the sysroot).

These commands don't handle many details of the full install process. In the case of blas and lapack - they don't handle the post install step of creating symlinks at `/usr/lib/${TRIPLE}/libblas.so`. This is important because this location is on the linkers default search path. The reason these symlinks are not part of the package by default is because blas and lapack are virtual packages, there are several different "concrete" packages that can satisfy the dependency (i.e. `libblas-dev`, `libopenblas-dev`, etc..). It's up the the debian alternatives system (& system administrators) to handle the detail of which concrete library the `libblas` and `liblapack` symlinks actually point to.

I explored a couple of routes to try to do this in a less janky way then manually creating the links, but this ended up being a rabbit hole. Ideally we revisit the way we're building these sysroots in a more robust way.

In the meantime we can now remove the hardcoded linker paths in libraries that depend on `blas` and `lapack`:
https://github.com/swift-nav/rules_swiftnav/blob/d10814e9b8f3d3b948e3ea9c1aed9c80c2fd74cc/third_party/suitesparse.BUILD#L25. Trying to handle all the different conditions (os, arch, sysroot or no sysroot, etc..) was becoming untenable, and just didn't work at all in some cases.

## Testing

I've tested the resulting sysroot build locally to verify that this mechanism of creating the links works.