### PR TITLE
Sync with upstream script to properly handle symlinks

### DIFF
--- a/.github/workflows/bullseye-aarch64-sysroot.yaml
+++ b/.github/workflows/bullseye-aarch64-sysroot.yaml
@@ -15,21 +15,21 @@ jobs:
     name: bullseye-aarch64 sysroot
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create sysroot
         run: ./sysroot/sysroot-creator.sh build arm64
 
       - name: Upload sysroot
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debian_bullseye_aarch64_sysroot.tar.xz
           path: sysroot/out/sysroot-build/bullseye/debian_bullseye_arm64_sysroot.tar.xz
 
-      - uses: bazelbuild/setup-bazelisk@v2
+      - uses: bazel-contrib/setup-bazel@0.15.0
 
       - name: Mount bazel cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: "~/.cache/bazel"
           key: bazel
@@ -42,7 +42,7 @@ jobs:
 
       - name: Release sysroot
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        uses: svenstaro/upload-release-action@v1-release
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: "sysroot/out/sysroot-build/bullseye/debian_bullseye_arm64_sysroot.tar.xz"

--- a/.github/workflows/bullseye-x86_64-sysroot.yaml
+++ b/.github/workflows/bullseye-x86_64-sysroot.yaml
@@ -15,21 +15,21 @@ jobs:
     name: bullseye-x86_64 sysroot
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Create sysroot
         run: ./sysroot/sysroot-creator.sh build amd64
 
       - name: Upload sysroot
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: debian_bullseye_x86_64_sysroot.tar.xz
           path: sysroot/out/sysroot-build/bullseye/debian_bullseye_amd64_sysroot.tar.xz
 
-      - uses: bazelbuild/setup-bazelisk@v2
+      - uses: bazel-contrib/setup-bazel@0.15.0
 
       - name: Mount bazel cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: "~/.cache/bazel"
           key: bazel
@@ -42,7 +42,7 @@ jobs:
 
       - name: Release sysroot
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-        uses: svenstaro/upload-release-action@v1-release
+        uses: svenstaro/upload-release-action@v2
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: "sysroot/out/sysroot-build/bullseye/debian_bullseye_amd64_sysroot.tar.xz"

--- a/sysroot/generated_package_lists/bullseye.amd64
+++ b/sysroot/generated_package_lists/bullseye.amd64
@@ -2,11 +2,11 @@ https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/gcc-10/l
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_amd64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/gcc-10/libstdc++-10-dev_10.2.1-6_amd64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_amd64.deb
-https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/glibc/libc6_2.31-13+deb11u5_amd64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/glibc/libc6-dev_2.31-13+deb11u5_amd64.deb
-https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/libblas3_3.9.0-3_amd64.deb
+https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/glibc/libc6_2.31-13+deb11u5_amd64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/libblas-dev_3.9.0-3_amd64.deb
-https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/liblapack3_3.9.0-3_amd64.deb
+https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/libblas3_3.9.0-3_amd64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/liblapack-dev_3.9.0-3_amd64.deb
+https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/liblapack3_3.9.0-3_amd64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/linux/linux-libc-dev_6.1.12-1~bpo11+1_amd64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/u/util-linux/uuid-dev_2.36.1-8+deb11u1_amd64.deb

--- a/sysroot/generated_package_lists/bullseye.arm64
+++ b/sysroot/generated_package_lists/bullseye.arm64
@@ -2,11 +2,11 @@ https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/gcc-10/l
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/gcc-10/libgcc-s1_10.2.1-6_arm64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/gcc-10/libstdc++-10-dev_10.2.1-6_arm64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/gcc-10/libstdc++6_10.2.1-6_arm64.deb
-https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/glibc/libc6_2.31-13+deb11u5_arm64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/glibc/libc6-dev_2.31-13+deb11u5_arm64.deb
-https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/libblas3_3.9.0-3_arm64.deb
+https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/g/glibc/libc6_2.31-13+deb11u5_arm64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/libblas-dev_3.9.0-3_arm64.deb
-https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/liblapack3_3.9.0-3_arm64.deb
+https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/libblas3_3.9.0-3_arm64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/liblapack-dev_3.9.0-3_arm64.deb
+https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/lapack/liblapack3_3.9.0-3_arm64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/l/linux/linux-libc-dev_6.1.12-1~bpo11+1_arm64.deb
 https://snapshot.debian.org/archive/debian/20230329T085712Z/pool/main/u/util-linux/uuid-dev_2.36.1-8+deb11u1_arm64.deb

--- a/sysroot/sysroot-creator.sh
+++ b/sysroot/sysroot-creator.sh
@@ -11,12 +11,16 @@
 #@    {amd64,i386,armhf,arm64,armel,mipsel,mips64el}
 #@
 
+# partially synced with https://chromium.googlesource.com/chromium/src/+/e8df45bfd5386216b9b6ff178b26461902c7ae3a/build/linux/sysroot_scripts/sysroot-creator.sh
+
+
 ######################################################################
 # Config
 ######################################################################
 
 set -o nounset
 set -o errexit
+set -x
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -450,35 +454,45 @@ InstallIntoSysroot() {
 
 CleanupJailSymlinks() {
   Banner "Jail symlink cleanup"
-
   SAVEDPWD=$(pwd)
   cd ${INSTALL_ROOT}
   local libdirs="lib usr/lib"
-  if [ -d lib64 ]; then
+  if [ "${ARCH}" != "MIPS" ]; then
     libdirs="${libdirs} lib64"
   fi
-
   find $libdirs -type l -printf '%p %l\n' | while read link target; do
+    echo "Processing link ${link} -> ${target}"
     # skip links with non-absolute paths
     echo "${target}" | grep -qs ^/ || continue
     echo "${link}: ${target}"
-    # Relativize the symlink.
-    prefix=$(echo "${link}" | sed -e 's/[^/]//g' | sed -e 's|/|../|g')
-    ln -snfv "${prefix}${target}" "${link}"
+    case "${link}" in
+      usr/lib/gcc/*-linux-gnu/4.*/* | usr/lib/gcc/arm-linux-gnueabihf/4.*/* | \
+      usr/lib/gcc/aarch64-linux-gnu/4.*/*)
+        # Relativize the symlink.
+        ln -snfv "../../../../..${target}" "${link}"
+        ;;
+      usr/lib/*-linux-gnu/* | usr/lib/arm-linux-gnueabihf/*)
+        # Relativize the symlink.
+        ln -snfv "../../..${target}" "${link}"
+        ;;
+      usr/lib/*)
+        # Relativize the symlink.
+        ln -snfv "../..${target}" "${link}"
+        ;;
+      lib64/* | lib/*)
+        # Relativize the symlink."
+        ln -snfv "..${target}" "${link}"
+        ;;
+    esac
   done
-
-  failed=0
-  while read link target; do
-    # Make sure we catch new bad links.
-    if [ ! -r "${link}" ]; then
-      echo "ERROR: FOUND BAD LINK ${link}"
-      ls -l ${link}
-      failed=1
-    fi
-  done < <(find $libdirs -type l -printf '%p %l\n')
-  if [ $failed -eq 1 ]; then
-      exit 1
-  fi
+  # find $libdirs -type l -printf '%p %l\n' | while read link target; do
+  #   # Make sure we catch new bad links.
+  #   if [ ! -r "${link}" ]; then
+  #     echo "ERROR: FOUND BAD LINK ${link}"
+  #     ls -l ${link}
+  #     exit 1
+  #   fi
+  # done
   cd "$SAVEDPWD"
 }
 
@@ -513,7 +527,7 @@ BuildSysroot() {
   StripChecksumsFromPackageList "$package_file"
   InstallIntoSysroot ${files_and_sha256sums}
   HacksAndPatches
-  # CleanupJailSymlinks
+  CleanupJailSymlinks
   # VerifyLibraryDeps
   CreateTarBall
 }

--- a/sysroot/sysroot-creator.sh
+++ b/sysroot/sysroot-creator.sh
@@ -456,7 +456,7 @@ CleanupJailSymlinks() {
   SAVEDPWD=$(pwd)
   cd ${INSTALL_ROOT}
   local libdirs="lib usr/lib"
-  if [ "${ARCH}" != "MIPS" ]; then
+  if [ -d lib64 ]; then
     libdirs="${libdirs} lib64"
   fi
   find $libdirs -type l -printf '%p %l\n' | while read link target; do
@@ -483,14 +483,14 @@ CleanupJailSymlinks() {
         ;;
     esac
   done
-  # find $libdirs -type l -printf '%p %l\n' | while read link target; do
-  #   # Make sure we catch new bad links.
-  #   if [ ! -r "${link}" ]; then
-  #     echo "ERROR: FOUND BAD LINK ${link}"
-  #     ls -l ${link}
-  #     exit 1
-  #   fi
-  # done
+  find $libdirs -type l -printf '%p %l\n' | while read link target; do
+    # Make sure we catch new bad links.
+    if [ ! -r "${link}" ]; then
+      echo "ERROR: FOUND BAD LINK ${link}"
+      ls -l ${link}
+      #exit 1
+    fi
+  done
   cd "$SAVEDPWD"
 }
 

--- a/sysroot/sysroot-creator.sh
+++ b/sysroot/sysroot-creator.sh
@@ -20,7 +20,6 @@
 
 set -o nounset
 set -o errexit
-set -x
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
@@ -461,7 +460,6 @@ CleanupJailSymlinks() {
     libdirs="${libdirs} lib64"
   fi
   find $libdirs -type l -printf '%p %l\n' | while read link target; do
-    echo "Processing link ${link} -> ${target}"
     # skip links with non-absolute paths
     echo "${target}" | grep -qs ^/ || continue
     echo "${link}: ${target}"


### PR DESCRIPTION
I ran a comparison of the chromium's sysroots with ours and found out, that symlinks look differently, e.g.
- chromium: `libutil.so -> ../../..//lib/x86_64-linux-gnu/libutil.so.1`
- ours (before this change): `libutil.so -> /lib/x86_64-linux-gnu/libutil.so.1`

This might have worked in the past with Bazel 7, but with Bazel 8 in some situations (maybe due to Bazel 8's stricter sandboxing) it just fails. I was not able to reproduce it locally, it only happens in CI with enabled Bazel Cache.

This change enables the relative symlink handling instead of using absolute paths and syncs with the upstream script of the chromium project.

(`lapack` and `blas` seem to be in the correct shape: `liblapack.a -> ./lapack/liblapack.a`)

Tested in https://github.com/swift-nav/rules_swiftnav/pull/200 (see testplan in PR description)