### PR TITLE
Provide blas/lapack standalone

### DIFF
--- a/.github/workflows/bullseye-blas-lapack-release.yaml
+++ b/.github/workflows/bullseye-blas-lapack-release.yaml
@@ -1,0 +1,44 @@
+---
+name: bullseye blas/lapack release
+on:
+  pull_request:
+    paths:
+      - "sysroot/**"
+      - .github/workflows/bullseye-blas-lapack-release.yaml
+  push:
+    tags:
+      - "bullseye-blas-lapack-*"
+
+jobs:
+  blas-lapack:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - arch: amd64
+            asset_name: debian_bullseye_x86_64_blas_lapack.tar.xz
+          - arch: arm64
+            asset_name: debian_bullseye_aarch64_blas_lapack.tar.xz
+    name: bullseye blas/lapack ${{ matrix.arch }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Package blas/lapack
+        run: ./sysroot/blas-lapack-packager.sh ${{ matrix.arch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset_name }}
+          path: sysroot/out/sysroot-build/bullseye/debian_bullseye_${{ matrix.arch }}_blas_lapack.tar.xz
+
+      - name: Release blas/lapack
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: "sysroot/out/sysroot-build/bullseye/debian_bullseye_${{ matrix.arch }}_blas_lapack.tar.xz"
+          tag: ${{ github.ref }}
+          asset_name: ${{ matrix.asset_name }}
+          overwrite: true

--- a/sysroot/blas-lapack-packager.sh
+++ b/sysroot/blas-lapack-packager.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# Builds the sysroot and packages blas and lapack libraries + headers into a
+# standalone tarball suitable for cc_import consumption.
+#
+# Usage:
+#   blas-lapack-packager.sh {amd64,arm64}
+
+set -o nounset
+set -o errexit
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+DISTRO=debian
+RELEASE=bullseye
+
+SetEnvironmentVariables() {
+  case $ARCH in
+    amd64)
+      TRIPLE=x86_64-linux-gnu
+      ;;
+    arm64)
+      TRIPLE=aarch64-linux-gnu
+      ;;
+    *)
+      echo "ERROR: Unsupported architecture: $ARCH"
+      echo "Usage: $0 {amd64,arm64}"
+      exit 1
+      ;;
+  esac
+
+  BUILD_DIR="${SCRIPT_DIR}/out/sysroot-build/${RELEASE}"
+  INSTALL_ROOT="${BUILD_DIR}/${RELEASE}_${ARCH}_staging"
+  TARBALL="${BUILD_DIR}/${DISTRO}_${RELEASE}_${ARCH}_blas_lapack.tar.xz"
+}
+
+PackageBlasLapack() {
+  if [ ! -d "${INSTALL_ROOT}" ]; then
+    echo "ERROR: staging dir not found: ${INSTALL_ROOT}"
+    echo "Run sysroot-creator.sh build ${ARCH} first."
+    exit 1
+  fi
+
+  local lib_src="${INSTALL_ROOT}/usr/lib/${TRIPLE}"
+  local inc_src="${INSTALL_ROOT}/usr/include"
+  local stage="${BUILD_DIR}/blas_lapack_${ARCH}_stage"
+
+  rm -rf "${stage}"
+  mkdir -p "${stage}/lib" "${stage}/include"
+
+  # Static libs (from blas/ and lapack/ subdirs placed there by the deb)
+  cp "${lib_src}/blas/libblas.a"     "${stage}/lib/"
+  cp "${lib_src}/lapack/liblapack.a" "${stage}/lib/"
+
+  echo "Creating ${TARBALL}"
+  tar -I "xz -9 -T0" -cf "${TARBALL}" -C "${stage}" .
+  echo "Done: ${TARBALL}"
+}
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 {amd64,arm64}"
+  exit 1
+fi
+
+ARCH=$1
+SetEnvironmentVariables
+"${SCRIPT_DIR}/sysroot-creator.sh" build "${ARCH}"
+PackageBlasLapack


### PR DESCRIPTION
Implement a simple workflow, which tries to provide blas and lapack standalone for consumption with `cc_import` downstream.